### PR TITLE
remove hello world

### DIFF
--- a/src/components/blocks/block_text.go.html
+++ b/src/components/blocks/block_text.go.html
@@ -1,7 +1,6 @@
 {{ define "block_text" }}
 <!-- <div>{{ . }}</div> -->
 <div class="prose max-w-7xl mx-auto edges-sm py-5 md:py-10">
-  <h1>Hello world</h1>
   <div>{{ .content | noescape }}</div>
 </div>
 {{ end }}


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request removes the hardcoded "Hello world" text from the `block_text` component.
> 
> ## What changed
> The hardcoded "Hello world" text was removed from the `block_text` component. Now, the component will only display the content passed to it.
> 
> ```diff
> -  <h1>Hello world</h1>
>    <div>{{ .content | noescape }}</div>
> ```
> 
> ## How to test
> To test this change, you can pass some content to the `block_text` component and verify that only the passed content is displayed, and the "Hello world" text is no longer present.
> 
> ## Why make this change
> This change was made to make the `block_text` component more flexible and reusable. With this change, the component can be used to display any text content, not just "Hello world".
</details>