### PR TITLE
add link preloading and page private (client side) cache headers to page routes

### DIFF
--- a/main.go
+++ b/main.go
@@ -94,11 +94,17 @@ func main() {
 			if err != nil {
 				log.Fatalf("Error parsing block templates: %v", err)
 			}
+
+			w.Header().Add("Cache-Control", fmt.Sprintf("private, max-age=%d", 60))
+
 			if err := tmpl.Execute(w, data); err != nil {
 				log.Println("Error executing template:", err)
 			}
 		}
 	}
+
+
+	
 
 	mux.Handle("/static/", maxAgeHandler(15552000, http.StripPrefix("/static/", fileServer)))
 	mux.HandleFunc("/", requestHandler)

--- a/src/components/blocks/block_hero.go.html
+++ b/src/components/blocks/block_hero.go.html
@@ -54,7 +54,10 @@
 
         <div class="mt-10 flex items-center justify-center gap-x-6">
           {{ range .buttons }}
-          <a href="{{ .href }}" class="button button-{{ .variant }}"
+          <a
+            preload="mouseover"
+            href="{{ .href }}"
+            class="button button-{{ .variant }}"
             >{{ .label }}</a
           >
           {{ end }}

--- a/src/components/head.go.html
+++ b/src/components/head.go.html
@@ -13,10 +13,17 @@
     href="/static/favicon.ico?v={{ .Version }}"
   />
 
-  <!-- <script
+  <script
     defer
-    src="https://unpkg.com/htmx.org@1.9.6/dist/htmx.min.js"
-  ></script> -->
+    src="https://unpkg.com/htmx.org@1.9.7/dist/htmx.min.js"
+  ></script>
+
+  <script
+    defer
+    src="https://unpkg.com/htmx.org@1.9.7/dist/ext/preload.js"
+  ></script>
+
+  <!-- <script defer src="https://unpkg.com/htmx.org/dist/ext/preload.js"></script> -->
 
   <!-- deferred loading of google font css -->
   <!-- <link

--- a/src/components/navbar.go.html
+++ b/src/components/navbar.go.html
@@ -1,8 +1,9 @@
 {{ define "navbar" }}
 <div class="relative z-10 shadow-md">
   <nav class="mx-auto flex max-w-screen-2xl items-center justify-between p-5">
-    <a href="/">Logo</a>
-    <div class="ml-auto flex gap-x-3">
+    <a preload="preload:init" href="/">Logo</a>
+    <div preload="preload:init" class="ml-auto flex gap-x-3">
+      <!-- <a preload="mouseover" href="/typography-demo">Typography Demo</a> -->
       <a href="/typography-demo">Typography Demo</a>
       <a href="/blocks-kitchen-sink">Page Blocks</a>
     </div>

--- a/src/templates/index.go.html
+++ b/src/templates/index.go.html
@@ -1,8 +1,8 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en" class="h-full">
   {{ template "head" . }}
 
-  <body class="min-h-screen flex flex-col justify-between">
+  <body hx-ext="preload" class="flex min-h-screen flex-col justify-between">
     <div>
       {{ template "navbar" . }}
 


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request introduces several changes to improve the performance of the website by adding cache control headers, preloading links on mouseover, and updating the htmx library to the latest version.
> 
> ## What changed
> - Added a `Cache-Control` header to the main.go file to cache the website for 60 seconds.
> - Added a `preload` attribute to links in the block_hero.go.html, navbar.go.html, and head.go.html files. This attribute preloads the linked content when the user hovers over the link, improving the perceived loading speed.
> - Updated the htmx library from version 1.9.6 to 1.9.7 in the head.go.html file. This update includes performance improvements and bug fixes.
> - Added the htmx preload extension to the head.go.html file. This extension enables the `preload` attribute functionality.
> - Changed the DOCTYPE declaration from uppercase to lowercase in the index.go.html file for consistency with HTML5 standards.
> - Added the `hx-ext="preload"` attribute to the body tag in the index.go.html file. This attribute enables the htmx preload extension for the entire page.
> 
> ## How to test
> 1. Pull the changes from this branch into your local environment.
> 2. Run the website and navigate to different pages. The pages should load faster due to the caching and preloading.
> 3. Hover over links without clicking. The linked content should start loading in the background.
> 4. Check the network tab in your browser's developer tools. The `Cache-Control` header should be present with a value of `private, max-age=60`.
> 
> ## Why make this change
> These changes improve the performance and user experience of the website. The caching reduces the load on the server and the preloading makes the website feel faster to the user. The htmx library update and preload extension enable these performance improvements.
</details>