### PR TITLE
adding hx boost to become PWA when clicking links

### DIFF
--- a/src/components/navbar.go.html
+++ b/src/components/navbar.go.html
@@ -1,8 +1,12 @@
 {{ define "navbar" }}
 <div class="relative z-10 shadow-md">
-  <nav class="mx-auto flex max-w-screen-2xl items-center justify-between p-5">
-    <a preload="preload:init" href="/">Logo</a>
-    <div preload="preload:init" class="ml-auto flex gap-x-3">
+  <nav
+    hx-boost="true"
+    preload="preload:init"
+    class="mx-auto flex max-w-screen-2xl items-center justify-between p-5"
+  >
+    <a href="/">Logo</a>
+    <div class="ml-auto flex gap-x-3">
       <!-- <a preload="mouseover" href="/typography-demo">Typography Demo</a> -->
       <a href="/typography-demo">Typography Demo</a>
       <a href="/blocks-kitchen-sink">Page Blocks</a>


### PR DESCRIPTION
Becoming more like a PWA, while still having a functional HTML fallback.

Add hx-boost and preload:init to navbar links.

Now, each page linked in the navbar will be preloaded before the user ever clicks it.

When the user clicks a link in the navbar it will use JS to swap the <body> element in the DOM and push to history state instead of performing a full navigation.

